### PR TITLE
Handle empty list in pairwise cyclic

### DIFF
--- a/src/SpiralMatrixSharp/FSharp.fs
+++ b/src/SpiralMatrixSharp/FSharp.fs
@@ -43,14 +43,16 @@ module Array2D =
 
 module List =
     let pairwiseCyclic source =
-        let head = List.head source
-        let rec loop source' =
-            match source' with
-            | [] -> []
-            | [x] -> [x, head]
-            | x :: y :: rest -> (x, y) :: loop (y :: rest)
-
-        loop source
+        if List.isEmpty source
+        then []
+        else
+            let head = List.head source
+            let rec loop source' =
+                match source' with
+                | [] -> []
+                | [x] -> [x, head]
+                | x :: y :: rest -> (x, y) :: loop (y :: rest)
+            loop source
 
 type CycleNode<'T> internal (item: 'T) as this =
     let mutable next = this

--- a/test/SpiralMatrixSharpTest/FSharpTest.fs
+++ b/test/SpiralMatrixSharpTest/FSharpTest.fs
@@ -35,3 +35,9 @@ let ``Pairwise cyclic empty list returns it as is`` () =
     let expected = List.empty
     Assert.That(actual, Is.EqualTo expected)
     
+[<Test>]
+let ``Pairwise cyclic list with one element`` () =
+    let actual = List.pairwiseCyclic ['a']
+    let expected = [('a', 'a')]
+    Assert.That(actual, Is.EqualTo expected)
+    

--- a/test/SpiralMatrixSharpTest/FSharpTest.fs
+++ b/test/SpiralMatrixSharpTest/FSharpTest.fs
@@ -1,0 +1,37 @@
+//
+// Copyright 2019 Bang Jun-young
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+// IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+module SpiralMatrixSharp.FSharpTest
+
+open NUnit.Framework
+
+module List = FSharp.List
+
+[<Test>]
+let ``Pairwise cyclic empty list returns it as is`` () =
+    let actual = List.pairwiseCyclic List.empty
+    let expected = List.empty
+    Assert.That(actual, Is.EqualTo expected)
+    

--- a/test/SpiralMatrixSharpTest/FSharpTest.fs
+++ b/test/SpiralMatrixSharpTest/FSharpTest.fs
@@ -40,4 +40,10 @@ let ``Pairwise cyclic list with one element`` () =
     let actual = List.pairwiseCyclic ['a']
     let expected = [('a', 'a')]
     Assert.That(actual, Is.EqualTo expected)
-    
+
+[<Test>]
+let ``Pairwise cyclic list with multiple elements`` () =
+    let actual = List.pairwiseCyclic ['a'; 'b'; 'c'; 'c']
+    let expected = [('a', 'b'); ('b', 'c'); ('c', 'c'); ('c', 'a')]
+    Assert.That(actual, Is.EqualTo expected)
+        

--- a/test/SpiralMatrixSharpTest/SpiralMatrixSharpTest.fsproj
+++ b/test/SpiralMatrixSharpTest/SpiralMatrixSharpTest.fsproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="FSharpTest.fs" />
     <Compile Include="SpiralMatrixTest.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
- Handle the case of an empty list as argument to the `pairwiseCyclic` function, because `List.head` throws an exception with it.
- Add tests.